### PR TITLE
Get rid of tons of warnings

### DIFF
--- a/src/main/java/com/elmakers/mine/bukkit/action/BaseProjectileAction.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/BaseProjectileAction.java
@@ -75,7 +75,7 @@ public abstract class BaseProjectileAction extends CompoundAction {
                     if (value.getOwningPlugin().equals(plugin)) {
                         Object o = value.value();
                         if (o != null && o instanceof WeakReference) {
-                            WeakReference reference = (WeakReference)o;
+                            WeakReference<?> reference = (WeakReference<?>)o;
                             o = reference.get();
                             if (o != null && o instanceof Entity) {
                                 targetEntity = (Entity)o;

--- a/src/main/java/com/elmakers/mine/bukkit/action/BaseShopAction.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/BaseShopAction.java
@@ -477,8 +477,6 @@ public abstract class BaseShopAction extends BaseSpellAction implements GUIActio
 
         this.showingItems = new HashMap<Integer, ShopItem>();
 
-        MageController controller = context.getController();
-
         // Load items
         itemStacks = new ArrayList<ItemStack>();
         String costString = context.getMessage("cost_lore", "Costs: $cost");

--- a/src/main/java/com/elmakers/mine/bukkit/action/CastContext.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/CastContext.java
@@ -16,7 +16,6 @@ import com.elmakers.mine.bukkit.spell.BlockSpell;
 import com.elmakers.mine.bukkit.spell.BrushSpell;
 import com.elmakers.mine.bukkit.spell.TargetingSpell;
 import com.elmakers.mine.bukkit.spell.UndoableSpell;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.Location;

--- a/src/main/java/com/elmakers/mine/bukkit/action/CastContext.java
+++ b/src/main/java/com/elmakers/mine/bukkit/action/CastContext.java
@@ -1051,7 +1051,6 @@ public class CastContext implements com.elmakers.mine.bukkit.api.action.CastCont
     public Double getReflective(Block block) {
         if (block == null) return null;
 
-        if (block == null) return null;
         if (targetingSpell != null && targetingSpell.isReflective(block.getType())) {
             return 1.0;
         }

--- a/src/main/java/com/elmakers/mine/bukkit/batch/UndoBatch.java
+++ b/src/main/java/com/elmakers/mine/bukkit/batch/UndoBatch.java
@@ -4,7 +4,6 @@ import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.block.BlockData;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.magic.MageController;
-import com.elmakers.mine.bukkit.block.BlockList;
 import com.elmakers.mine.bukkit.block.UndoList;
 import org.bukkit.Material;
 

--- a/src/main/java/com/elmakers/mine/bukkit/block/BlockComparator.java
+++ b/src/main/java/com/elmakers/mine/bukkit/block/BlockComparator.java
@@ -1,6 +1,5 @@
 package com.elmakers.mine.bukkit.block;
 
-import com.elmakers.mine.bukkit.api.block.*;
 import org.bukkit.Material;
 
 import java.util.Comparator;

--- a/src/main/java/com/elmakers/mine/bukkit/block/NegatedHashSet.java
+++ b/src/main/java/com/elmakers/mine/bukkit/block/NegatedHashSet.java
@@ -2,7 +2,9 @@ package com.elmakers.mine.bukkit.block;
 
 import java.util.HashSet;
 
-public class NegatedHashSet<T> extends HashSet {
+public class NegatedHashSet<T> extends HashSet<T> {
+    private static final long serialVersionUID = 1L;
+
     @Override
     public boolean contains(Object o) {
         return !super.contains(o);

--- a/src/main/java/com/elmakers/mine/bukkit/block/UndoQueue.java
+++ b/src/main/java/com/elmakers/mine/bukkit/block/UndoQueue.java
@@ -208,7 +208,6 @@ public class UndoQueue implements com.elmakers.mine.bukkit.api.block.UndoQueue
         try {
             if (data == null) return;
             List<com.elmakers.mine.bukkit.api.block.UndoList> undoList = data.getBlockList();
-            if (data == null) return;
             if (undoList != null) {
                 for (com.elmakers.mine.bukkit.api.block.UndoList list : undoList) {
                     add(list);

--- a/src/main/java/com/elmakers/mine/bukkit/block/WildcardHashSet.java
+++ b/src/main/java/com/elmakers/mine/bukkit/block/WildcardHashSet.java
@@ -2,7 +2,7 @@ package com.elmakers.mine.bukkit.block;
 
 import java.util.HashSet;
 
-public class WildcardHashSet<T> extends HashSet {
+public class WildcardHashSet<T> extends HashSet<T> {
     @Override
     public boolean contains(Object o) {
         return true;

--- a/src/main/java/com/elmakers/mine/bukkit/block/WildcardHashSet.java
+++ b/src/main/java/com/elmakers/mine/bukkit/block/WildcardHashSet.java
@@ -3,6 +3,8 @@ package com.elmakers.mine.bukkit.block;
 import java.util.HashSet;
 
 public class WildcardHashSet<T> extends HashSet<T> {
+    private static final long serialVersionUID = 1L;
+
     @Override
     public boolean contains(Object o) {
         return true;

--- a/src/main/java/com/elmakers/mine/bukkit/data/ConfigurationMageDataStore.java
+++ b/src/main/java/com/elmakers/mine/bukkit/data/ConfigurationMageDataStore.java
@@ -10,6 +10,7 @@ import com.elmakers.mine.bukkit.api.data.UndoData;
 import com.elmakers.mine.bukkit.api.magic.MageController;
 import com.elmakers.mine.bukkit.api.wand.Wand;
 import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -305,7 +306,9 @@ public abstract class ConfigurationMageDataStore implements MageDataStore {
 
         // Load stored inventory
         if (saveFile.contains("inventory")) {
-            data.setStoredInventory((List<ItemStack>) saveFile.getList("inventory"));
+            @SuppressWarnings("unchecked")
+            List<ItemStack> inventory = (List<ItemStack>) saveFile.getList("inventory");
+            data.setStoredInventory(inventory);
         }
         if (saveFile.contains("experience")) {
             data.setStoredExperience((float)saveFile.getDouble("experience"));

--- a/src/main/java/com/elmakers/mine/bukkit/effect/EffectPlayer.java
+++ b/src/main/java/com/elmakers/mine/bukkit/effect/EffectPlayer.java
@@ -18,7 +18,6 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;

--- a/src/main/java/com/elmakers/mine/bukkit/effect/EffectPlayer.java
+++ b/src/main/java/com/elmakers/mine/bukkit/effect/EffectPlayer.java
@@ -4,8 +4,10 @@ import java.util.*;
 
 import com.elmakers.mine.bukkit.api.effect.EffectPlay;
 import com.elmakers.mine.bukkit.utility.SoundEffect;
+
 import de.slikey.effectlib.util.DynamicLocation;
 import de.slikey.effectlib.util.ParticleEffect;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Effect;
@@ -622,6 +624,7 @@ public abstract class EffectPlayer implements com.elmakers.mine.bukkit.api.effec
                         throw new Exception("Must extend EffectPlayer");
                     }
 
+                    @SuppressWarnings("unchecked")
                     Class<? extends EffectPlayer> playerClass = (Class<? extends EffectPlayer>)genericClass;
                     EffectPlayer player = playerClass.newInstance();
                     player.load(plugin, effectValues);

--- a/src/main/java/com/elmakers/mine/bukkit/effect/EffectUtils.java
+++ b/src/main/java/com/elmakers/mine/bukkit/effect/EffectUtils.java
@@ -2,13 +2,11 @@ package com.elmakers.mine.bukkit.effect;
 
 import com.elmakers.mine.bukkit.api.action.CastContext;
 import com.elmakers.mine.bukkit.api.magic.Mage;
-import com.elmakers.mine.bukkit.utility.CompatibilityUtils;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Server;
-import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -19,7 +17,6 @@ import com.elmakers.mine.bukkit.utility.NMSUtils;
 import org.bukkit.util.Vector;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Random;
 

--- a/src/main/java/com/elmakers/mine/bukkit/effect/EffectUtils.java
+++ b/src/main/java/com/elmakers/mine/bukkit/effect/EffectUtils.java
@@ -62,7 +62,7 @@ public class EffectUtils extends NMSUtils {
                 Object metadataPacket = class_PacketPlayOutEntityMetadata_Constructor.newInstance(fireworkId, watcher, true);
                 Object statusPacket = class_PacketPlayOutEntityStatus_Constructor.newInstance(fireworkHandle, (byte)17);
 
-                Constructor packetDestroyEntityConstructor = class_PacketPlayOutEntityDestroy.getConstructor(int[].class);
+                Constructor<?> packetDestroyEntityConstructor = class_PacketPlayOutEntityDestroy.getConstructor(int[].class);
                 Object destroyPacket = packetDestroyEntityConstructor.newInstance(new int[] {(Integer)fireworkId});
 
                 Collection<? extends Player> players = server.getOnlinePlayers();

--- a/src/main/java/com/elmakers/mine/bukkit/effect/HoloUtils.java
+++ b/src/main/java/com/elmakers/mine/bukkit/effect/HoloUtils.java
@@ -20,7 +20,7 @@ public class HoloUtils extends NMSUtils
         Object skull = null;
         try {
             Object world = getHandle(location.getWorld());
-            Constructor skullConstructor = class_EntityWitherSkull.getConstructor(class_World);
+            Constructor<?> skullConstructor = class_EntityWitherSkull.getConstructor(class_World);
             skull = skullConstructor.newInstance(world);
             Method setLocationMethod = skull.getClass().getMethod("setLocation", Double.TYPE, Double.TYPE, Double.TYPE, Float.TYPE, Float.TYPE);
             setLocationMethod.invoke(skull, location.getX(), location.getY() + Y_OFFSET, location.getZ(), location.getPitch(), location.getYaw());
@@ -37,7 +37,7 @@ public class HoloUtils extends NMSUtils
         Object horse = null;
         try {
             Object world = getHandle(location.getWorld());
-            Constructor horseConstructor = class_EntityHorse.getConstructor(class_World);
+            Constructor<?> horseConstructor = class_EntityHorse.getConstructor(class_World);
             horse = horseConstructor.newInstance(world);
 
             Method setAgeMethod = horse.getClass().getMethod("setAge", Integer.TYPE);
@@ -93,7 +93,7 @@ public class HoloUtils extends NMSUtils
         try {
             Object horsePacket = class_PacketSpawnLivingEntityConstructor.newInstance(horse);
             Object skullPacket = class_PacketSpawnEntityConstructor.newInstance(skull, WITHER_SKULL_TYPE);
-            Constructor packetAttachEntityConstructor = class_PacketPlayOutAttachEntity.getConstructor(Integer.TYPE, class_Entity, class_Entity);
+            Constructor<?> packetAttachEntityConstructor = class_PacketPlayOutAttachEntity.getConstructor(Integer.TYPE, class_Entity, class_Entity);
             Object attachPacket = packetAttachEntityConstructor.newInstance(0, horse, skull);
 
             sendPacket(player, horsePacket);
@@ -115,7 +115,7 @@ public class HoloUtils extends NMSUtils
             int horseId = (int)(Integer)getHorseIdMethod.invoke(horse);
             int skullId = (int)(Integer)getSkullIdMethod.invoke(skull);
 
-            Constructor packetDestroyEntityConstructor = class_PacketPlayOutEntityDestroy.getConstructor(int[].class);
+            Constructor<?> packetDestroyEntityConstructor = class_PacketPlayOutEntityDestroy.getConstructor(int[].class);
             Object destroyPacket = packetDestroyEntityConstructor.newInstance(new int[] {horseId, skullId});
 
             sendPacket(player, destroyPacket);

--- a/src/main/java/com/elmakers/mine/bukkit/integration/VaultController.java
+++ b/src/main/java/com/elmakers/mine/bukkit/integration/VaultController.java
@@ -15,7 +15,6 @@ import java.text.NumberFormat;
 public class VaultController {
     private static VaultController instance;
     private Economy economy;
-    private Plugin owningPlugin;
     private NumberFormat formatter = new DecimalFormat("#0.00");
 
     public static VaultController getInstance() {
@@ -48,7 +47,6 @@ public class VaultController {
     }
 
     private VaultController(Plugin owner, Economy economy) {
-        this.owningPlugin = owner;
         this.economy = economy;
     }
 

--- a/src/main/java/com/elmakers/mine/bukkit/maps/MapController.java
+++ b/src/main/java/com/elmakers/mine/bukkit/maps/MapController.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class MapController implements com.elmakers.mine.bukkit.api.maps.MapController {

--- a/src/main/java/com/elmakers/mine/bukkit/math/EquationTransform.java
+++ b/src/main/java/com/elmakers/mine/bukkit/math/EquationTransform.java
@@ -1,6 +1,5 @@
 package com.elmakers.mine.bukkit.math;
 
-import com.avaje.ebean.LogLevel;
 import com.elmakers.mine.bukkit.api.math.Transform;
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;

--- a/src/main/java/com/elmakers/mine/bukkit/math/VectorTransform.java
+++ b/src/main/java/com/elmakers/mine/bukkit/math/VectorTransform.java
@@ -1,7 +1,6 @@
 package com.elmakers.mine.bukkit.math;
 
 import com.elmakers.mine.bukkit.api.math.Transform;
-import de.slikey.effectlib.util.MathUtils;
 import de.slikey.effectlib.util.VectorUtils;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;

--- a/src/main/java/com/elmakers/mine/bukkit/spell/BaseSpell.java
+++ b/src/main/java/com/elmakers/mine/bukkit/spell/BaseSpell.java
@@ -29,6 +29,7 @@ import com.elmakers.mine.bukkit.api.wand.Wand;
 import com.elmakers.mine.bukkit.api.wand.WandUpgradePath;
 import com.elmakers.mine.bukkit.utility.CompatibilityUtils;
 import com.elmakers.mine.bukkit.utility.InventoryUtils;
+
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
@@ -940,7 +941,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
                 if (effectsNode.isString(effectKey)) {
                     String referenceKey = effectsNode.getString(effectKey);
                     if (effects.containsKey(referenceKey)) {
-                        effects.put(effectKey, new ArrayList(effects.get(referenceKey)));
+                        effects.put(effectKey, new ArrayList<EffectPlayer>(effects.get(referenceKey)));
                     }
                 }
                 else

--- a/src/main/java/com/elmakers/mine/bukkit/spell/BaseSpell.java
+++ b/src/main/java/com/elmakers/mine/bukkit/spell/BaseSpell.java
@@ -703,6 +703,7 @@ public abstract class BaseSpell implements MageSpell, Cloneable {
             case WITCH:
                 mobSkin = "MHF_Witch";
                 break;
+            default:
         }
 
         return mobSkin;

--- a/src/main/java/com/elmakers/mine/bukkit/spell/BlockSpell.java
+++ b/src/main/java/com/elmakers/mine/bukkit/spell/BlockSpell.java
@@ -6,14 +6,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.elmakers.mine.bukkit.block.UndoList;
-import com.elmakers.mine.bukkit.utility.CompatibilityUtils;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.InventoryHolder;
 
 public abstract class BlockSpell extends UndoableSpell {
 

--- a/src/main/java/com/elmakers/mine/bukkit/spell/CastingCost.java
+++ b/src/main/java/com/elmakers/mine/bukkit/spell/CastingCost.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import com.elmakers.mine.bukkit.api.magic.Messages;
 import com.elmakers.mine.bukkit.integration.VaultController;
 import org.bukkit.Material;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import com.elmakers.mine.bukkit.api.magic.Mage;

--- a/src/main/java/com/elmakers/mine/bukkit/spell/TargetingSpell.java
+++ b/src/main/java/com/elmakers/mine/bukkit/spell/TargetingSpell.java
@@ -1,7 +1,6 @@
 package com.elmakers.mine.bukkit.spell;
 
 import com.elmakers.mine.bukkit.api.action.CastContext;
-import com.elmakers.mine.bukkit.api.block.UndoList;
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.elmakers.mine.bukkit.api.spell.TargetType;
 import com.elmakers.mine.bukkit.block.MaterialAndData;
@@ -10,7 +9,6 @@ import com.elmakers.mine.bukkit.utility.ConfigurationUtils;
 import com.elmakers.mine.bukkit.utility.Target;
 import com.elmakers.mine.bukkit.utility.Targeting;
 import org.bukkit.Bukkit;
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -23,7 +21,6 @@ import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;

--- a/src/main/java/com/elmakers/mine/bukkit/utility/CompatibilityUtils.java
+++ b/src/main/java/com/elmakers/mine/bukkit/utility/CompatibilityUtils.java
@@ -1,6 +1,7 @@
 package com.elmakers.mine.bukkit.utility;
 
 import com.elmakers.mine.bukkit.api.block.MaterialAndData;
+
 import org.bukkit.Art;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -250,6 +251,7 @@ public class CompatibilityUtils extends NMSUtils {
             location = getPaintingOffset(location, facing, art);
             Object worldHandle = getHandle(location.getWorld());
             Object newEntity = null;
+            @SuppressWarnings("unchecked")
             Enum<?> directionEnum = Enum.valueOf(class_EnumDirection, facing.name());
             Object blockLocation = class_BlockPositionConstructor.newInstance(location.getX(), location.getY(), location.getZ());
             newEntity = class_EntityPaintingConstructor.newInstance(worldHandle, blockLocation, directionEnum);
@@ -275,6 +277,7 @@ public class CompatibilityUtils extends NMSUtils {
         try {
             Object worldHandle = getHandle(location.getWorld());
             Object newEntity = null;
+            @SuppressWarnings("unchecked")
             Enum<?> directionEnum = Enum.valueOf(class_EnumDirection, facing.name());
             Object blockLocation = class_BlockPositionConstructor.newInstance(location.getX(), location.getY(), location.getZ());
             newEntity = class_EntityItemFrameConstructor.newInstance(worldHandle, blockLocation, directionEnum);
@@ -373,6 +376,7 @@ public class CompatibilityUtils extends NMSUtils {
                     location.getX() + x, location.getY() + y, location.getZ() + z);
 
             // The input entity is only used for equivalency testing, so this "null" should be ok.
+            @SuppressWarnings("unchecked")
             List<? extends Object> entityList = (List<? extends Object>)class_World_getEntitiesMethod.invoke(worldHandle, null, bb);
             List<Entity> bukkitEntityList = new java.util.ArrayList<org.bukkit.entity.Entity>(entityList.size());
 
@@ -422,6 +426,7 @@ public class CompatibilityUtils extends NMSUtils {
         return newMinecart;
     }
 
+    @SuppressWarnings("unchecked")
     public static Class<? extends Runnable> getTaskClass(BukkitTask task) {
         Class<? extends Runnable> taskClass = null;
         try {

--- a/src/main/java/com/elmakers/mine/bukkit/utility/ConfigurationUtils.java
+++ b/src/main/java/com/elmakers/mine/bukkit/utility/ConfigurationUtils.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.Map.Entry;
 
 import de.slikey.effectlib.util.ParticleEffect;
+
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
@@ -300,10 +301,10 @@ public class ConfigurationUtils {
         if (value instanceof Map)
         {
             ConfigurationSection newChild = base.createSection(key);
-            Map<String, Object> map = (Map<String, Object>)value;
-            for (Entry<String, Object> entry : map.entrySet())
+            Map<?, ?> map = (Map<?, ?>)value;
+            for (Entry<?, ?> entry : map.entrySet())
             {
-                newChild.set(entry.getKey(), entry.getValue());
+                newChild.set((String) entry.getKey(), entry.getValue());
             }
             base.set(key, newChild);
             return newChild;

--- a/src/main/java/com/elmakers/mine/bukkit/utility/ConfigurationUtils.java
+++ b/src/main/java/com/elmakers/mine/bukkit/utility/ConfigurationUtils.java
@@ -10,7 +10,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.block.Block;

--- a/src/main/java/com/elmakers/mine/bukkit/utility/InventoryUtils.java
+++ b/src/main/java/com/elmakers/mine/bukkit/utility/InventoryUtils.java
@@ -2,6 +2,7 @@ package com.elmakers.mine.bukkit.utility;
 
 import com.elmakers.mine.bukkit.api.magic.Mage;
 import com.google.common.collect.Multimap;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -149,6 +150,7 @@ public class InventoryUtils extends NMSUtils
             return null;
         }
         try {
+            @SuppressWarnings("unchecked")
             Multimap<String, Object> properties = (Multimap<String, Object>)class_GameProfile_properties.get(profile);
             Collection<Object> textures = properties.get("textures");
             if (textures != null && textures.size() > 0)

--- a/src/main/java/com/elmakers/mine/bukkit/utility/SoundEffect.java
+++ b/src/main/java/com/elmakers/mine/bukkit/utility/SoundEffect.java
@@ -1,6 +1,5 @@
 package com.elmakers.mine.bukkit.utility;
 
-import com.elmakers.mine.bukkit.api.magic.MageController;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Location;
 import org.bukkit.Sound;


### PR DESCRIPTION
Removes / suppresses a lot of warnings.

Warnings not (yet) fixed / questions:
- Unused warning on the following two https://github.com/elBukkit/MagicLib/blob/master/src/main/java/com/elmakers/mine/bukkit/block/Schematic.java#L29
  I'm not really sure what this is, should it just have a getter?
- Dead code in here https://github.com/elBukkit/MagicLib/blob/master/src/main/java/com/elmakers/mine/bukkit/utility/BoundingBox.java#L143 potential bug?
- Bukkit deprecation warnings. Should those just be ignored or actually fixed?
